### PR TITLE
[update] 記事のパンくずリストでカテゴリは後ろに文字を追加せずカテゴリ名そのままに変更

### DIFF
--- a/src/components/server/Article/Article.tsx
+++ b/src/components/server/Article/Article.tsx
@@ -38,7 +38,7 @@ export function Article({ meta, content }: ArticleProps) {
       href: `/articles/list/`, // TODO: 全記事一覧ページのリンク
     },
     {
-      name: `${meta.category.name}記事一覧`,
+      name: `${meta.category.name}`,
       href: `/categories/hoge/list/`, // TODO: カテゴリ記事一覧ページのリンク
     },
     {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d81f0360-ad76-4781-9b87-3e4518259d4a)
